### PR TITLE
Clean up b-ber-create pdf-task

### DIFF
--- a/packages/b-ber-create/src/bber-output/pdf/index.es6
+++ b/packages/b-ber-create/src/bber-output/pdf/index.es6
@@ -6,25 +6,21 @@
 import Promise from 'zousan'
 import path from 'path'
 import fs from 'fs-extra'
-import Yaml from 'bber-lib/yaml'
+import store from 'bber-lib/store'
 import html2pdf from 'html-pdf'
 import Printer from 'bber-modifiers/printer'
 import log from 'b-ber-logger'
-import { src, dist, build } from 'bber-utils'
+import { src, dist } from 'bber-utils'
 import { isPlainObject } from 'lodash'
 
 const writeOutput = false
 
-let input
 let output
-let buildType
 let printer
 let settings
 
 const initialize = () => {
-    input = src()
     output = dist()
-    buildType = build()
     printer = new Printer(output)
     settings = {
         fname: `${new Date().toISOString().replace(/:/g, '-')}.pdf`,
@@ -39,11 +35,11 @@ const initialize = () => {
                 right: '14mm',
             },
             header: {
-                height: '14mm',
+                height: '7mm',
                 contents: '<div style="text-align: center; font-family:Helvetica; font-size:12px; color: lightgrey;">Made with bber</div>', // eslint-disable-line max-len
             },
             footer: {
-                height: '5mm',
+                height: '7mm',
                 contents: {
                     //first: 'Cover page',
                     //2: 'Second page',
@@ -51,7 +47,6 @@ const initialize = () => {
                     //last: 'Last Page'
                 },
             },
-            //zoomFactor: '1', // default is 1
             base: `file://${output}${path.sep}OPS${path.sep}Text${path.sep}`,
             timeout: 10000,
         },
@@ -106,13 +101,12 @@ const print = content =>
         })
     })
 
-
 const pdf = () =>
     new Promise(async (resolve) => {
         await initialize()
-        const manifest = Yaml.load(path.join(input, `${buildType}.yml`))
-
+        const manifest = store.spine.map((n) => n.fileName)
         parseHTML(manifest)
+        
         // TODO: pass `writeOutput` flag to determine if the task also outputs
         // XHTML version
         .then(content => write(content))
@@ -120,5 +114,5 @@ const pdf = () =>
         .catch(err => log.error(err))
         .then(resolve)
     })
-
+    
 export default pdf


### PR DESCRIPTION
Replaces `buildtype.yml `with `store.spine`, and removes redundant and unused variables