### PR TITLE
Final styles

### DIFF
--- a/packages/b-ber-lib/src/ApplicationLoader.js
+++ b/packages/b-ber-lib/src/ApplicationLoader.js
@@ -27,7 +27,20 @@ class ApplicationLoader {
             remote_url: 'http://localhost:4000/',
             reader_url: 'http://localhost:4000/project-reader',
             builds: ['epub', 'mobi', 'pdf'],
-            ui_theme: './themes',
+            ui_options: {
+                navigation: {
+                    header_icons: {
+                        info: true,
+                        home: true,
+                        downloads: true,
+                        toc: true,
+                    },
+                    footer_icons: {
+                        chapter: true,
+                        page: true,
+                    },
+                },
+            },
             private: false,
             ignore: [],
             autoprefixer_options: {

--- a/packages/b-ber-reader/src/components/App.jsx
+++ b/packages/b-ber-reader/src/components/App.jsx
@@ -14,7 +14,7 @@ class App extends Component {
             defaultBookURL: props.bookURL || null,
             basePath: props.basePath || '/',
             downloads: props.downloads || [],
-            uiTheme: props.uiTheme || '/',
+            uiOptions: props.uiOptions || {},
             loadRemoteLibrary: typeof props.loadRemoteLibrary !== 'undefined' ? props.loadRemoteLibrary : /^localhost/.test(window.location.host),
         }
 

--- a/packages/b-ber-reader/src/components/Navigation/NavigationFooter.jsx
+++ b/packages/b-ber-reader/src/components/Navigation/NavigationFooter.jsx
@@ -8,6 +8,7 @@ const NavigationFooter = props => (
                 <li>
                     <button
                         className='material-icons nav__button'
+                        style={props.uiOptions.navigation.footer_icons.chapter ? {} : {display: "none"}}
                         onClick={_ => {
                             if (props.handleEvents === false) return
                             props.handleChapterNavigation(-1)
@@ -18,6 +19,7 @@ const NavigationFooter = props => (
                 <li>
                     <button
                         className='material-icons nav__button'
+                        style={props.uiOptions.navigation.footer_icons.page ? {} : {display: "none"}}
                         onClick={_ => {
                             if (props.handleEvents === false) return
                             props.enablePageTransitions()
@@ -29,6 +31,7 @@ const NavigationFooter = props => (
                 <li>
                     <button
                         className='material-icons nav__button'
+                        style={props.uiOptions.navigation.footer_icons.page ? {} : {display: "none"}}
                         onClick={_ => {
                             if (props.handleEvents === false) return
                             props.enablePageTransitions()
@@ -40,6 +43,7 @@ const NavigationFooter = props => (
                 <li>
                     <button
                         className='material-icons nav__button'
+                        style={props.uiOptions.navigation.footer_icons.chapter ? {} : {display: "none"}}
                         onClick={_ => {
                             if (props.handleEvents === false) return
                             props.handleChapterNavigation(1)

--- a/packages/b-ber-reader/src/components/Navigation/NavigationHeader.jsx
+++ b/packages/b-ber-reader/src/components/Navigation/NavigationHeader.jsx
@@ -9,6 +9,7 @@ const NavigationHeader = props => (
                     <button
                         className='material-icons nav__button nav__button__chapters'
                         onClick={props.destroyReaderComponent}
+                        style={props.uiOptions.navigation.header_icons.home ? {} : {display: "none"}}
                     >menu
                     </button>
                 </li>
@@ -16,6 +17,7 @@ const NavigationHeader = props => (
                     <button
                         className='material-icons nav__button nav__button__chapters'
                         onClick={_ => props.handleSidebarButtonClick('chapters')}
+                        style={props.uiOptions.navigation.header_icons.toc ? {} : {display: "none"}}
                     >view_list
                     </button>
                 </li>
@@ -30,6 +32,7 @@ const NavigationHeader = props => (
                     <button
                         className='material-icons nav__button nav__button__downloads'
                         onClick={_ => props.handleSidebarButtonClick('downloads')}
+                        style={props.uiOptions.navigation.header_icons.downloads ? {} : {display: "none"}}
                     >file_download
                     </button>
                 </li>
@@ -37,6 +40,7 @@ const NavigationHeader = props => (
                     <button
                         className='material-icons nav__button nav__button__metadata'
                         onClick={_ => props.handleSidebarButtonClick('metadata')}
+                        style={props.uiOptions.navigation.header_icons.info ? {} : {display: "none"}}
                     >info_outline
                     </button>
                 </li>

--- a/packages/b-ber-reader/src/components/Reader.jsx
+++ b/packages/b-ber-reader/src/components/Reader.jsx
@@ -629,7 +629,7 @@ class Reader extends Component {
                 handleSidebarButtonClick={this.handleSidebarButtonClick}
                 navigateToChapterByURL={this.navigateToChapterByURL}
                 downloads={this.props.downloads}
-                uiTheme={this.props.uiTheme}
+                uiOptions={this.props.uiOptions}
             >
                 <Frame
                     hash={hash}

--- a/packages/b-ber-reader/src/index.scss
+++ b/packages/b-ber-reader/src/index.scss
@@ -91,6 +91,7 @@ a {
 
         li {
             display: flex;
+            min-width: 30px;
 
             &:nth-child(2) {
                 flex: 1;

--- a/packages/b-ber-tasks/src/reader/index.js
+++ b/packages/b-ber-tasks/src/reader/index.js
@@ -134,21 +134,7 @@ class Reader {
             downloads: this.getProjectConfig('builds'),
             basePath: this.getProjectConfig('base_path'),
             loadRemoteLibrary: false,
-            uiTheme: this.getProjectConfig('ui_theme'),
-            // uiTheme: {
-            //     navigation: {
-            //         header_icons: [{
-            //             home: this.getBookMetadata('home'),
-            //             toc: this.getBookMetadata('toc'),
-            //             downloads: this.getBookMetadata('downloads'),
-            //             info: this.getBookMetadata('info'),
-            //         }],
-            //         footer_icons: [{
-            //             chapter_next: this.getBookMetadata('chapter_next'),
-            //             page_next: this.getBookMetadata('chapter_next'),
-            //         }],
-            //     },
-            // },
+            uiOptions: this.getProjectConfig('ui_options'),
         }
 
         let contents


### PR DESCRIPTION
Fixes #131 

## Proposed Changes

Adds entry point for `ui_options` config object with ability to set display settings for ui header and footer nav icons.

`ui_options` object gets included in projects `config.yml` file as follows:

```yaml
// my_project/config.yml

theme: tc-theme-crimson
themes_directory: ./my-themes
..
ui_options:
  navigation:
    header_icons:
      home: false
      toc : true
      downloads : true
      info: false
    footer_icons: 
      page : true
      chapter : false
```

Includes the following default / fallback config that sets all items to true in the case that `ui_optons` is not defined in `config.yml` file:

```js
// b-ber/packages/b-ber-lib/src/ApplicationLoader.js

ui_options: {
  navigation: {
     header_icons: {
       info: true,
       home: true,
       downloads: true,
       toc: true,
     },
     footer_icons: {
       chapter: true,
       page: true,
     },
  },
},
```
