### PR TITLE
Squash commits; pulls in orig. Genus Family on draft & depre. directives

### DIFF
--- a/packages/b-ber-grammar/src/syntax/helpers/index.js
+++ b/packages/b-ber-grammar/src/syntax/helpers/index.js
@@ -168,6 +168,8 @@ const _extendWithDefaults = (obj, genus) => {
             taxonomy = `${_lookUpFamily(genus)} ${genus}` // -> `bodymatter chapter`
             result.epubTypes = taxonomy
             if ({}.hasOwnProperty.call(obj, 'classes')) {
+                taxonomy = `${_lookUpFamily(result.classes)} ${genus}`
+                result.epubTypes = taxonomy
                 result.classes += ` ${taxonomy}` // -> class="... bodymatter chapter"
             } else {
                 result.classes = taxonomy // -> class="bodymatter chapter"
@@ -211,17 +213,10 @@ const attributesObject = (attrs, _genus, context = {}) => {
     }
 
     if (DRAFT_DIRECTIVES.indexOf(genus) > -1) {
-        if (BACKMATTER_DIRECTIVES.indexOf(genus) > -1) {
-            log.warn(
-                `render [epub:${genus}] is [draft]. substituting with [backmatter].`,
-            )
-            genus = 'backmatter'
-        } else {
-            log.warn(
-                `render [epub:${genus}] is [draft]. substituting with [chapter].`,
-            )
-            genus = 'chapter'
-        }
+        log.warn(
+            `render [epub:${genus}] is [draft]. substituting with [chapter].`,
+        )
+        genus = 'chapter'
     }
 
     if (DEPRECATED_DIRECTIVES.indexOf(genus) > -1) {


### PR DESCRIPTION
Fixes #147 

>  The Series and Credits sections are not pulling in the “backmatter” class and instead are pulling in the body matter class. The front-matter in the markdown is correct.

further elaborated in [dc66b8](https://github.com/triplecanopy/b-ber/commit/dc66b810ff224a10e34b404e0c633461666fec0a#commitcomment-30559484)

## Proposed Changes

Terms here are a little confusing, so I'm using classification defined by the [b-ber-grammar syntax](https://github.com/triplecanopy/b-ber/blob/master/packages/b-ber-grammar/src/syntax/helpers/index.js#L19)

```
// packages/b-ber-grammar/src/syntax/helpers/index.js

// Class    -> Order  -> Family       -> Genus
// element  -> block  -> frontmatter  -> Credits
```

If a directive's `genus` ("Credits", "Series-page") is changed to "Chapter" due it either belonging to a ` DEPRECATED_DIRECTIVES` or `DRAFT_DIRECTIVES` `family` as defined in [b-ber-shapes/directives](https://github.com/triplecanopy/b-ber/blob/master/packages/b-ber-shapes/src/directives/index.js), supply the `family` of the **original** `genus` ("Credits", "Series-page")  to the elements `class` and `epub:type` attributes.

**Markdown Input:** `::: credits:credits-title`

**HTML Output:** 
```html
class="credits backmatter chapter"

epub:type="backmatter chapter"
```
